### PR TITLE
Changed jquery selector to work with 'MarkItUp' enhanced fields. 

### DIFF
--- a/assets/preview_textarea.publish.js
+++ b/assets/preview_textarea.publish.js
@@ -12,7 +12,7 @@ jQuery(document).ready(function($) {
 
 	$('a.preview-textarea-button').click(function(event) {
 		event.preventDefault();
-		var thePackage = $(this).siblings('textarea');
+		var thePackage = $(this).parent().find('textarea');
 		if (thePackage.val().length == 0) {
 			$(this).after('&#160;<strong>This textarea is empty!</strong>').next().delay(5000).fadeOut('slow');
 		}


### PR DESCRIPTION
I changed the jquery textarea selector to work with MarkItUp, by removing the restricting of having the textarea as a sibling of the preview link. MarkItUp adds a few extra containing elements around the textarea, so the previous selector was unable to find it. This continues to work with the 'regular' textarea field types. 
